### PR TITLE
Add ability to add context.

### DIFF
--- a/lib/providers/default.js
+++ b/lib/providers/default.js
@@ -10,7 +10,7 @@ DefaultProvider.prototype.format =  function(logEvent, layout){
         level_id: logEvent.level.level,
         level: logEvent.level.levelStr,
         timestamp: logEvent.startTime.getTime() + (logEvent.startTime.getTimezoneOffset() * 60000),
-        context: logEvent.context,
-        message: layout(logEvent)
+        message: layout(logEvent),
+        ...logEvent.context && { context: logEvent.context }
     }
 }

--- a/lib/providers/default.js
+++ b/lib/providers/default.js
@@ -10,6 +10,7 @@ DefaultProvider.prototype.format =  function(logEvent, layout){
         level_id: logEvent.level.level,
         level: logEvent.level.levelStr,
         timestamp: logEvent.startTime.getTime() + (logEvent.startTime.getTimezoneOffset() * 60000),
+        context: logEvent.context,
         message: layout(logEvent)
     }
 }


### PR DESCRIPTION
Hi Mike,

Jose here from URP IBM Team. I used to work with Mark Lindsay for BaaS and CCP. We are using your library and we have a story that needs context by doing `logger.addContext('key', 'value');` Just thought maybe you'd allow this PR so we can add context on our project. Please let me know if I need to do something first or if you will be enabling context yourself. 

Thank you.